### PR TITLE
Add support for incremental build

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,16 @@ To use this plugin, you must
 
 | Option | Default value | Description | 
 | ------ | ------------- | ----------- |
-| generatedWsdlDir | generated-sources/src/main/java | this is where you want the generated sources to be placed. |
-| wsdlsToGenerate | empty| this is the main input to the plugin that defines the wsdls to process. It is a list of arguments where each argument is a list of arguments to process a wsdl-file. The Wsdl-file with full path is the last argument. The array can be supplied with the same options as described for the maven-cxf plugin(http://cxf.apache.org/docs/wsdl-to-java.html). | 
-| cxfVersion | '+' (latest)| The version of cxf you want to use. |
+| generatedWsdlDir | generated-sources/src/main/java | This is where you want the generated sources to be placed. |
+| wsdlDir | src/main/resources | Define the wsdl files directory to support incremental build. This means that the task will be up-to-date if nothing in this directory has changed. |
+| wsdlsToGenerate | empty | This is the main input to the plugin that defines the wsdls to process. It is a list of arguments where each argument is a list of arguments to process a wsdl-file. The Wsdl-file with full path is the last argument. The array can be supplied with the same options as described for the maven-cxf plugin(http://cxf.apache.org/docs/wsdl-to-java.html). |
+| cxfVersion | '+' (latest) | The version of cxf you want to use. |
 
 Example setting of options:
 
-    wsdl2java{
-        generatedWsdlDir = "my-generated-sources"  // target directory for generated source coude
+    wsdl2java {
+        generatedWsdlDir = file("my-generated-sources")  // target directory for generated source coude
+        wsdlDir = file("src/main/resources/myWsdlFiles") // define to support incremental build
         wsdlsToGenerate = [   //  2d-array of wsdls and cxf-parameters
                     ['src/main/resources/wsdl/firstwsdl.wsdl'],
                     ['-xcj','-b','bingingfile.xml','src/main/resources/wsdl/secodwsdl.wsdl']
@@ -88,6 +90,7 @@ This is a an example of a working build.gradle for a java project. You can also 
         wsdlsToGenerate = [
                 ['src/main/resources/wsdl/stockqoute.wsdl']
         ]
-        generatedWsdlDir = "generatedsources"
+        generatedWsdlDir = file("generatedsources")
+        wsdlDir = file("src/main/resources/wsdl")
         cxfVersion = "3.0.1"
     }

--- a/consumer/build.gradle
+++ b/consumer/build.gradle
@@ -25,7 +25,8 @@ wsdl2java{
     wsdlsToGenerate = [
             ['src/main/resources/wsdl/stockqoute.wsdl']
     ]
-    generatedWsdlDir = "generatedsources"
+    generatedWsdlDir = file("generatedsources")
+    wsdlDir = file("src/main/resources/wsdl")
     cxfVersion = "2.5.1"
 }
 

--- a/plugin/src/main/groovy/no/nils/wsdl2java/Wsdl2JavaTask.groovy
+++ b/plugin/src/main/groovy/no/nils/wsdl2java/Wsdl2JavaTask.groovy
@@ -2,13 +2,21 @@ package no.nils.wsdl2java
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskExecutionException
 
 class Wsdl2JavaTask extends DefaultTask {
     // user properties
     String cxfVersion = "+"
-    String generatedWsdlDir = "generated-sources/src/main/java"
+
+    @InputDirectory
+    File wsdlDir = new File("src/main/resources")
+
+    @OutputDirectory
+    File generatedWsdlDir = new File("generated-sources/src/main/java")
+
     def wsdlsToGenerate
 
     // build internal properties


### PR DESCRIPTION
Define inputs and outputs on the wsdl2java task. Gradle will then set the task to up-to-date if no files in the input or output directories have changed. Allows one to e.g. change a property file without having to regenerate all wsdl files. It can also speed up the build time, depending on how many/big wsdl files there are.
