### PR TITLE
possible solution to #13 - Passing XJC Parameters in xsd2Java

### DIFF
--- a/consumer/build.gradle
+++ b/consumer/build.gradle
@@ -1,20 +1,20 @@
 buildscript{
-	repositories{
-		maven {
+    repositories{
+        maven {
             url uri('../repo')
         }
         mavenCentral()
-	}
-	dependencies {
-		classpath 'no.nils:wsdl2java:+'
-	}
+    }
+    dependencies {
+        classpath 'no.nils:wsdl2java:+'
+    }
 }
 
 apply plugin :'idea'
 apply plugin :'no.nils.wsdl2java'
 
 repositories{
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies(){
@@ -24,7 +24,7 @@ dependencies(){
 
 wsdl2java{
     wsdlsToGenerate = [
-            [file('src/main/resources/wsdl/stockqoute.wsdl')]
+        [file('src/main/resources/wsdl/stockqoute.wsdl')]
     ]
     generatedWsdlDir = file("generatedsources/wsdl2java")
     wsdlDir = file("src/main/resources/wsdl")
@@ -32,8 +32,9 @@ wsdl2java{
 }
 
 xsd2java{
+    encoding = 'utf-8'
     xsdsToGenerate = [
-            [file("src/main/resources/xsd/CustomersAndOrders.xsd"), 'no.nils.xsd2java.sample']
+        [file("src/main/resources/xsd/CustomersAndOrders.xsd"), 'no.nils.xsd2java.sample']
     ]
     generatedXsdDir = file("generatedsources/xsd2java")
 }

--- a/plugin/src/main/groovy/no/nils/wsdl2java/Wsdl2JavaPlugin.groovy
+++ b/plugin/src/main/groovy/no/nils/wsdl2java/Wsdl2JavaPlugin.groovy
@@ -55,7 +55,8 @@ class Wsdl2JavaPlugin implements Plugin<Project> {
 
             // add jaxb-xjc
             project.dependencies {
-                xsd2java 'com.sun.xml.bind:jaxb-xjc:2.2.4-1'
+                xsd2java 'com.sun.xml.bind:jaxb-xjc:2.2.5'
+                xsd2java 'com.sun.xml.bind:jaxb-impl:2.2.5'
             }
 
             // hook xsd2java into build cycle only if used

--- a/plugin/src/main/groovy/no/nils/wsdl2java/Xsd2JavaTask.groovy
+++ b/plugin/src/main/groovy/no/nils/wsdl2java/Xsd2JavaTask.groovy
@@ -15,6 +15,7 @@ class Xsd2JavaTask extends DefaultTask {
 
     Configuration classpath
     def xsdsToGenerate
+    def encoding
 
     @TaskAction
     public void xsd2java() {
@@ -26,10 +27,16 @@ class Xsd2JavaTask extends DefaultTask {
         }
 
         xsdsToGenerate.each() { schemaAndPackage ->
+            def options = [
+                destdir: generatedXsdDir,
+                package: schemaAndPackage[1],
+                schema: schemaAndPackage[0]
+            ]
+            if (encoding != null) {
+                options.encoding = encoding
+            }
             ant.xjc(
-                    destdir: generatedXsdDir,
-                    package: schemaAndPackage[1],
-                    schema: schemaAndPackage[0]
+                options  
             )
         }
 


### PR DESCRIPTION
Hi Nils,

I'm a teammate of Thorben who created #13 therefore I'm very interested in having the problem solved.

The parameter that is stopping us from using the xsd2java task is the one to configure the encoding. As i know now this parameter was added to XJCTask in Jaxb 2.2.5 and my commit consists of upgrading jaxb, passing through the encoding and using this parameter in the consumer test (an error message when using an invalid encoding proved that the parameter was used).

Maybe it'd be good to upgrade to the latest version but for now I was careful not breaking too much.

Thank you very much, your plugin has saved us lots of coding in the build script and surely days of work.

Best regards
Steven
