### PR TITLE
Additional options for the xsd2java task

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,10 @@ Example setting of options:
 | Option | Default value | Description |
 | ------ | ------------- | ----------- |
 | generatedXsdDir | "generatedsources/src/main/java" | Destination directory for generated sources |
-| xsdsToGenerate | null | 2-d array consisting of 2 values in each array: xsd-file(input) and package for the generated sources |
+| xsdsToGenerate | null | 2-d array consisting of 2 or 3 values in each array: 
+1. xsd-file(input) 
+2. package for the generated sources 
+3. (optional) a map containing additional options for the xjc task |
 | encoding | platform default encoding | Set the encoding name for generated sources, such as EUC-JP or UTF-8. |
 
 Example setting of options:
@@ -89,7 +92,7 @@ Example setting of options:
     xsd2java{
         encoding = 'utf-8'
         xsdsToGenerate = [
-            ["src/main/resources/xsd/CustomersAndOrders.xsd", 'no.nils.xsd2java.sample']
+            ["src/main/resources/xsd/CustomersAndOrders.xsd", 'no.nils.xsd2java.sample', [header: false] /* optional map */]
         ]
         generatedXsdDir = file("generatedsources/xsd2java")
     }

--- a/README.md
+++ b/README.md
@@ -81,10 +81,7 @@ Example setting of options:
 | Option | Default value | Description |
 | ------ | ------------- | ----------- |
 | generatedXsdDir | "generatedsources/src/main/java" | Destination directory for generated sources |
-| xsdsToGenerate | null | 2-d array consisting of 2 or 3 values in each array: 
-1. xsd-file(input) 
-2. package for the generated sources 
-3. (optional) a map containing additional options for the xjc task |
+| xsdsToGenerate | null | 2-d array consisting of 2 or 3 values in each array: 1. xsd-file(input), 2. package for the generated sources, 3. (optional) a map containing additional options for the xjc task |
 | encoding | platform default encoding | Set the encoding name for generated sources, such as EUC-JP or UTF-8. |
 
 Example setting of options:

--- a/plugin/src/main/groovy/no/nils/wsdl2java/Xsd2JavaTask.groovy
+++ b/plugin/src/main/groovy/no/nils/wsdl2java/Xsd2JavaTask.groovy
@@ -32,6 +32,10 @@ class Xsd2JavaTask extends DefaultTask {
                 package: schemaAndPackage[1],
                 schema: schemaAndPackage[0]
             ]
+            // adding additional options to xjc task if available
+            if(schemaAndPackage.size() > 2) {
+                options << schemaAndPackage[2]
+            }
             if (encoding != null) {
                 options.encoding = encoding
             }


### PR DESCRIPTION
I gladly used this easy-to-use plugin until I noticed that each time the xsd2java task generated the java classes the header had changed. So, even without any further changes to the XSD, every file was different because the timestamp changed in the header.

So I added a third (fully optional) value to the array in the xsd2java task containing a map with additional options to the XJC task generating the class files. I simply put [header: false] to it and the classes were generated without the evil timestamp header.

So the plugin stays easy to use and expanded in possibilities at once.