### PR TITLE
Remove dependency on "org.apache.cxf:cxf-tools" 

### DIFF
--- a/plugin/src/main/groovy/no/nils/wsdl2java/Wsdl2JavaPlugin.groovy
+++ b/plugin/src/main/groovy/no/nils/wsdl2java/Wsdl2JavaPlugin.groovy
@@ -38,7 +38,6 @@ class Wsdl2JavaPlugin implements Plugin<Project> {
 
             // add cxf as dependency
             project.dependencies {
-                wsdl2java "org.apache.cxf:cxf-tools:$cxfVersion"
                 wsdl2java "org.apache.cxf:cxf-tools-wsdlto-databinding-jaxb:$cxfVersion"
                 wsdl2java "org.apache.cxf:cxf-tools-wsdlto-frontend-jaxws:$cxfVersion"
                 if (project.wsdl2java.wsdlsToGenerate.collect { it.contains('-xjc-Xts') }.contains(true)) {


### PR DESCRIPTION
This dependency does not exist in all versions (specifically 2.7.14).
It does not provide an artifact, and has no dependencies. So it is not clear to me, that it is actually necessary.
