### PR TITLE
New option "locale" for generated sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Contributions are welcome as long as they are sane.
 - Thorben Schiller, https://github.com/thorbolo
 - Stefan Kloe, https://github.com/Pentadrago
 - Mattias Rundgren, https://github.com/matrun
-- "s-doering", https://github.com/s-doering
+- Steffen Döring, https://github.com/s-doering
 - Jesper Skov, https://github.com/jskovjyskebankdk
 
 ### CXF
@@ -67,6 +67,7 @@ To use this plugin, you must
 | wsdlDir | src/main/resources | Define the wsdl files directory to support incremental build. This means that the task will be up-to-date if nothing in this directory has changed. |
 | wsdlsToGenerate | empty | This is the main input to the plugin that defines the wsdls to process. It is a list of arguments where each argument is a list of arguments to process a wsdl-file. The Wsdl-file with full path is the last argument. The array can be supplied with the same options as described for the maven-cxf plugin(http://cxf.apache.org/docs/wsdl-to-java.html). |
 | cxfVersion | '+' (latest) | The version of cxf you want to use. |
+| locale | Locale.getDefault() | The locale for the generated sources – especially the JavaDoc. This might be necessary to prevent differing sources due to several development environments. |
 
 Example setting of options:
 
@@ -78,6 +79,7 @@ Example setting of options:
                     ['-xjc','-b','bingingfile.xml','src/main/resources/wsdl/secodwsdl.wsdl']
             ]
         cxfVersion = "2.5.1"
+        locale = Locale.GERMANY
     }
 
 ### Options for xsd2java (deprecated, separate plugin coming soon)
@@ -130,6 +132,7 @@ This is a an example of a working build.gradle for a java project. You can also 
         generatedWsdlDir = file("$projectDir/generatedsources")
         wsdlDir = file("$projectDir/src/main/resources/wsdl")
         cxfVersion = "3.0.1"
+        locale = Locale.FRANCE
     }
      
 ### A notice on multi-module projects


### PR DESCRIPTION
We have several developers with different machines and locales.
Every time we build the application the WSDL classes will be generated. Depending on the machines locale the JavaDoc will be in a different locale and the generated sources change although the WSDL hasn't changed.
As the locale in XJC can't be set via arguments this must be done by setting the current default locale (and set back after sources generated).

This is a Pull Request for this feature.