### PR TITLE
Support -p with wsdl-namespace clause

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 }
 
 group = 'no.nils'
-version = '0.10-SNAPSHOT'
+version = '0.11-SNAPSHOT'
 
 uploadArchives {
     repositories {

--- a/plugin/src/main/groovy/no/nils/wsdl2java/Wsdl2JavaTask.groovy
+++ b/plugin/src/main/groovy/no/nils/wsdl2java/Wsdl2JavaTask.groovy
@@ -133,7 +133,10 @@ class Wsdl2JavaTask extends DefaultTask {
 			int packageArgIdx = args.indexOf("-p");
 			int packageIx = packageArgIdx+1;
 			if (packageArgIdx != -1 && args.size() >= packageIx) {
-				String pathPath = args.get(packageIx).replace(".", "/");
+				//check if it's wsdl-namespace=package
+				String[] maybeWsdlNameSpaceAndPackage= args.get(packageIx).split("=")
+				String packageName= maybeWsdlNameSpaceAndPackage.size() == 1 ? maybeWsdlNameSpaceAndPackage[0] : maybeWsdlNameSpaceAndPackage[1]
+				String pathPath= packageName.replace(".", "/");
 				packagePaths.add(pathPath);
 			}
 		}


### PR DESCRIPTION
Sorry to insist but i it seems you didn't read my last comment on the other closed pull request.

The problem is that current -p option puts all generated classes in the specified package but i have one wsdl that references two target name spaces, so classes from two different namespaces are merged in the same package.

After adding support to wsdl-namespace with this:

    wsdlsToGenerate = [
            ['-verbose', '-client' ,'-wsdlLocation','https://pre.bus.salut.gencat.cat/cmbd_aea/ws/public/NotificarActivitat_v01_00?wsdl', '-p', "http://salut.gencat.cat/cmbd/aea/v01=cat.gencat.salut.cmbd.aea.v01.notificaractivitat", '-xjc-verbose', '-b', "$projectDir/src/main/resources/wsdl/NotificarActivitat_v01_00_bind.xml", "$projectDir/src/main/resources/wsdl/NotificarActivitat_v01_00.wsdl"],
            ['-verbose', '-client' ,'-wsdlLocation','https://pre.bus.salut.gencat.cat/cmbd_aea/ws/public/ConsultaWeb_v01_00?wsdl', '-p', "http://salut.gencat.cat/cmbd/aea/v01=cat.gencat.salut.cmbd.aea.v01.consultaweb", '-xjc-verbose' , "$projectDir/src/main/resources/wsdl/ConsultaWeb_v01_00.wsdl"]
    ]

I get 3 packages
cat.gencat.salut.cmbd.aea.v01.notificaractivitat
org.hl7.v3
cat.gencat.salut.cmbd.aea.v01.consultaweb

Thanks