### PR TITLE
Create `wsd2java` configuration early for consuming projects to use

### DIFF
--- a/src/main/groovy/no/nils/wsdl2java/Wsdl2JavaPlugin.groovy
+++ b/src/main/groovy/no/nils/wsdl2java/Wsdl2JavaPlugin.groovy
@@ -21,6 +21,7 @@ class Wsdl2JavaPlugin implements Plugin<Project> {
 
         def extension = project.extensions.create(WSDL2JAVA, Wsdl2JavaPluginExtension.class)
         def cxfVersion = project.provider { extension.cxfVersion }
+        def wsdl2javaConfiguration = project.configurations.maybeCreate(WSDL2JAVA)
 
         // Get compile configuration and add Java 9+ dependencies if required.
         project.configurations.named("compile").configure {
@@ -33,9 +34,8 @@ class Wsdl2JavaPlugin implements Plugin<Project> {
 
         def wsdl2JavaTask = project.tasks.register(WSDL2JAVA, Wsdl2JavaTask.class) { task ->
             // Add new configuration for our plugin and add required dependencies to it.
-            def wsdl2javaConfiguration = project.configurations.maybeCreate(WSDL2JAVA)
 
-            wsdl2javaConfiguration.defaultDependencies {
+            wsdl2javaConfiguration.withDependencies {
                 it.add(project.dependencies.create("org.apache.cxf:cxf-tools-wsdlto-databinding-jaxb:${cxfVersion.get()}"))
                 it.add(project.dependencies.create("org.apache.cxf:cxf-tools-wsdlto-frontend-jaxws:${cxfVersion.get()}"))
                 it.add(project.dependencies.create("org.apache.cxf.xjcplugins:cxf-xjc-ts:${cxfVersion.get()}"))

--- a/src/test/resources/test-project/build.gradle
+++ b/src/test/resources/test-project/build.gradle
@@ -10,6 +10,11 @@ repositories {
 dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.5.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.5.2'
+        // enable extension support for wsdl2java
+    wsdl2java 'org.jvnet.jaxb2_commons:jaxb2-basics-runtime:0.11.0'
+    wsdl2java 'org.jvnet.jaxb2_commons:jaxb2-basics:0.11.0'
+    implementation 'org.jvnet.jaxb2_commons:jaxb2-basics-runtime:0.11.0'
+    implementation 'org.jvnet.jaxb2_commons:jaxb2-basics:0.11.0'
 }
 
 test {
@@ -18,6 +23,6 @@ test {
 
 wsdl2java {
     wsdlsToGenerate = [
-            [file('src/main/resources/wsdl/stockqoute.wsdl')]
+            ['-xjc-Xequals', '-xjc-XhashCode', file('src/main/resources/wsdl/stockqoute.wsdl')]
     ]
 }


### PR DESCRIPTION
This fixes issue #98.
I moved the creation of the project configuration `wsdl2java` up, so it gets created early on.
This makes it possible to use for the project using the wsdl2java plugin. 

Updated the supplied build.gradle in test to reflect the usage. For the test to pass, I needed the add the `implementation` too.
