### PR TITLE
Modified wsdl2java plugin to have a separate version number for plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ plugins {
 | encoding | platform default encoding | Set the encoding name for generated sources, such as EUC-JP or UTF-8. |
 | stabilizeAndMergeObjectFactory| false | If multiple WSDLs target the same package, merge their `ObjectFactory` classes. |
 | cxfVersion | "+" | Controls the CXF version used to generate code. |
+| cxfPluginVersion | "+" | Controls the CXF XJC-plugins version used to generate code. |
 
 Example setting of options:
 
@@ -94,6 +95,7 @@ wsdl2java {
     ]
     locale = Locale.GERMANY
     cxfVersion = "2.5.1"
+    cxfPluginVersion = "2.4.0"
 }
 ```
     
@@ -101,6 +103,7 @@ Kotlin:
 
 ```kotlin
 extra["cxfVersion"] = "3.3.2"
+extra["cxfPluginVersion"] = "3.2.2"
 
 wsdl2java {
     wsdlDir = file("$projectDir/src/main/wsdl")
@@ -165,6 +168,7 @@ wsdl2java {
     wsdlDir = file("$projectDir/src/main/resources/wsdl")
     locale = Locale.FRANCE
     cxfVersion = "2.5.1"
+    cxfPluginVersion = "2.4.0"
 }
 ```
 

--- a/src/main/groovy/no/nils/wsdl2java/Wsdl2JavaPlugin.groovy
+++ b/src/main/groovy/no/nils/wsdl2java/Wsdl2JavaPlugin.groovy
@@ -21,6 +21,7 @@ class Wsdl2JavaPlugin implements Plugin<Project> {
 
         def extension = project.extensions.create(WSDL2JAVA, Wsdl2JavaPluginExtension.class)
         def cxfVersion = project.provider { extension.cxfVersion }
+        def cxfPluginVersion = project.provider { extension.cxfPluginVersion }
 
         // Add new configuration for our plugin and add required dependencies to it later.
         def wsdl2javaConfiguration = project.configurations.maybeCreate(WSDL2JAVA)
@@ -38,8 +39,12 @@ class Wsdl2JavaPlugin implements Plugin<Project> {
             wsdl2javaConfiguration.withDependencies {
                 it.add(project.dependencies.create("org.apache.cxf:cxf-tools-wsdlto-databinding-jaxb:${cxfVersion.get()}"))
                 it.add(project.dependencies.create("org.apache.cxf:cxf-tools-wsdlto-frontend-jaxws:${cxfVersion.get()}"))
-                it.add(project.dependencies.create("org.apache.cxf.xjcplugins:cxf-xjc-ts:${cxfVersion.get()}"))
-                it.add(project.dependencies.create("org.apache.cxf.xjcplugins:cxf-xjc-boolean:${cxfVersion.get()}"))
+                if (project.wsdl2java.wsdlsToGenerate.any { it.contains('-xjc-Xts') }) {
+                    it.add(project.dependencies.create("org.apache.cxf.xjcplugins:cxf-xjc-ts:${cxfPluginVersion.get()}"))
+                }
+                if (project.wsdl2java.wsdlsToGenerate.any { it.contains('-xjc-Xbg') }) {
+                    it.add(project.dependencies.create("org.apache.cxf.xjcplugins:cxf-xjc-boolean:${cxfPluginVersion.get()}"))
+                }
 
                 if (JavaVersion.current().isJava9Compatible()) {
                     JAVA_9_DEPENDENCIES.each { dep -> it.add(project.dependencies.create(dep)) }

--- a/src/main/groovy/no/nils/wsdl2java/Wsdl2JavaPluginExtension.groovy
+++ b/src/main/groovy/no/nils/wsdl2java/Wsdl2JavaPluginExtension.groovy
@@ -29,4 +29,8 @@ class Wsdl2JavaPluginExtension {
 
     @Input
     String cxfVersion = "+"
+
+    @Input
+    String cxfPluginVersion = "+"
+
 }


### PR DESCRIPTION
Modified wsdl2java plugin to have a separate version number for plugin dependencies and only load them if they are needed.

There already exists an old pull request for fixing this (#60), This is a new one targeting the lastest version of wsdl2java, I took the liberty to re add the argument flag that existed in previous versions of wsdl2java as that has worked well for us in the past and downloading fewer dependencies can be seen as desirable.
Let me know if that is not desirable.

This closes #37 