### PR TITLE
Add Java 9+ dependencies to implementation configuration instead of compile

### DIFF
--- a/src/main/groovy/no/nils/wsdl2java/Wsdl2JavaPlugin.groovy
+++ b/src/main/groovy/no/nils/wsdl2java/Wsdl2JavaPlugin.groovy
@@ -27,7 +27,7 @@ class Wsdl2JavaPlugin implements Plugin<Project> {
         def wsdl2javaConfiguration = project.configurations.maybeCreate(WSDL2JAVA)
 
         // Get compile configuration and add Java 9+ dependencies if required.
-        project.configurations.named("compile").configure {
+        project.configurations.named("implementation").configure {
             it.withDependencies {
                 if (JavaVersion.current().isJava9Compatible()) {
                     JAVA_9_DEPENDENCIES.each { dep -> it.add(project.dependencies.create(dep)) }


### PR DESCRIPTION
Compile configuration has been discouraged since Gradle 3.4.

https://docs.gradle.org/6.3/userguide/upgrading_version_5.html#dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations