### PR TITLE
Compile scope is deprecated and removed in gradle 7.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,14 +8,13 @@ plugins {
 }
 
 group = 'no.nils'
-version = '0.13-TRAVELC.3'
+version = '0.13-TRAVELC.16'
 
 // stay compatible with the crowd
-sourceCompatibility = JavaVersion.VERSION_1_6
-targetCompatibility = JavaVersion.VERSION_1_6
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 repositories {
-    jcenter()
     maven {
         url "https://jitpack.io"
     }
@@ -36,6 +35,7 @@ dependencies {
 
 java {
     withSourcesJar()
+    withJavadocJar()
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -2,13 +2,13 @@ plugins {
     id "groovy"
     id "maven-publish"
     id "java-gradle-plugin"
-    id "com.jfrog.bintray" version "1.8.4"
     id 'idea'
     id 'eclipse'
+    id 'maven'
 }
 
 group = 'no.nils'
-version = '0.13-SNAPSHOT'
+version = '0.13-TRAVELC.3'
 
 // stay compatible with the crowd
 sourceCompatibility = JavaVersion.VERSION_1_6
@@ -16,10 +16,14 @@ targetCompatibility = JavaVersion.VERSION_1_6
 
 repositories {
     jcenter()
+    maven {
+        url "https://jitpack.io"
+    }
 }
 
 dependencies {
     implementation localGroovy()
+    implementation("com.github.ertugrulcetin:CommentRemover:1.2")
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.5.2'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.5.2'
@@ -55,40 +59,18 @@ publishing {
     }
 }
 
-bintray {
-    apiUrl = "https://api.bintray.com"
-    user = System.env.BINTRAY_USER
-    key = System.env.BINTRAY_API_KEY
-
-    publications = ['maven'] //When uploading Maven-based publication files
-    // - AND/OR -
-    dryRun = false //Whether to run this as dry-run, without deploying
-    publish = true //If version should be auto published after an upload
-    pkg {
-        repo = 'maven'
-        //userOrg = 'no.nils' //An optional organization name when the repo belongs to one of the user's orgs
-        name = 'wsdl2java'
-        desc = 'Gradle wsdl2java plugin'
-        websiteUrl = 'https://github.com/nilsmagnus/wsdl2java'
-        issueTrackerUrl = 'https://github.com/nilsmagnus/wsdl2java/issues'
-        vcsUrl = 'https://github.com/nilsmagnus/wsdl2java.git'
-        licenses = ['MIT']
-        labels = ['gradle', 'wsdl2java', 'plugin']
-        publicDownloadNumbers = true
-        //Optional version descriptor
-        version {
-            name = project.version //Bintray logical version name
-            desc = ''
-            //released  = '' //2 possible values: date in the format of 'yyyy-MM-dd'T'HH:mm:ss.SSSZZ' OR a java.util.Date instance
-            vcsTag = project.version
-            attributes = ['gradle-plugin': 'no.nils.wsdl2java:no.nils:wsdl2java']
-            //Optional version-level attributes
-        }
-    }
-}
-
 wrapper {
     gradleVersion = '6.0.1'
+}
+
+uploadArchives {
+    repositories {
+        mavenDeployer {
+            repository(url: "https://nexus.travelcdev.com/repository/maven-releases") {
+                authentication(userName: "admin", password: "travelCompositor123")
+            }
+        }
+    }
 }
 
 build.doLast { uploadArchives }

--- a/src/main/groovy/no/nils/wsdl2java/Wsdl2JavaPlugin.groovy
+++ b/src/main/groovy/no/nils/wsdl2java/Wsdl2JavaPlugin.groovy
@@ -26,8 +26,8 @@ class Wsdl2JavaPlugin implements Plugin<Project> {
         // Add new configuration for our plugin and add required dependencies to it later.
         def wsdl2javaConfiguration = project.configurations.maybeCreate(WSDL2JAVA)
 
-        // Get compile configuration and add Java 9+ dependencies if required.
-        project.configurations.named("compile").configure {
+        // Get implementation configuration and add Java 9+ dependencies if required.
+        project.configurations.named("implementation").configure {
             it.withDependencies {
                 if (JavaVersion.current().isJava9Compatible()) {
                     JAVA_9_DEPENDENCIES.each { dep -> it.add(project.dependencies.create(dep)) }

--- a/src/main/groovy/no/nils/wsdl2java/Wsdl2JavaPlugin.groovy
+++ b/src/main/groovy/no/nils/wsdl2java/Wsdl2JavaPlugin.groovy
@@ -72,10 +72,6 @@ class Wsdl2JavaPlugin implements Plugin<Project> {
                 it.dependsOn wsdl2JavaTask
             }
         }
-
-        project.sourceSets {
-            main.java.srcDirs += Wsdl2JavaTask.DESTINATION_DIR
-        }
     }
 
     static Class<Task> getTaskClass(name) {

--- a/src/main/groovy/no/nils/wsdl2java/Wsdl2JavaPluginExtension.groovy
+++ b/src/main/groovy/no/nils/wsdl2java/Wsdl2JavaPluginExtension.groovy
@@ -12,6 +12,10 @@ class Wsdl2JavaPluginExtension {
     @PathSensitive(PathSensitivity.ABSOLUTE)
     File wsdlDir = new File(DEFAULT_WSDL_DIR)
 
+
+    @Input
+    String outputDirectory = "build/generated/"
+
     @Input
     List<List<Object>> wsdlsToGenerate
 

--- a/src/main/groovy/no/nils/wsdl2java/Wsdl2JavaPluginExtension.groovy
+++ b/src/main/groovy/no/nils/wsdl2java/Wsdl2JavaPluginExtension.groovy
@@ -22,6 +22,9 @@ class Wsdl2JavaPluginExtension {
     String encoding = Charset.defaultCharset().name()
 
     @Input
+    boolean removeComments = true
+
+    @Input
     boolean stabilize = false
 
     @Input


### PR DESCRIPTION
I just upgraded to gradle 7.0 (a milestone) and noticed this plugin fails. You are already using implementation scope so this change should not break any backward compatibility.
